### PR TITLE
[BUG FIX] Colleges don't give gold when they surrender

### DIFF
--- a/PirateGame/core/src/com/team21direction/pirategame/actions/WhiteFlagRoutine.java
+++ b/PirateGame/core/src/com/team21direction/pirategame/actions/WhiteFlagRoutine.java
@@ -27,6 +27,8 @@ public class WhiteFlagRoutine extends Action {
             college.screen.experience += college.screen.experiencePerCollege;
             college.setCollegeName(college.screen.player.parentCollege.getCollegeName());
             college.isWhiteFlag = false;
+            college.collegeBase = new Sprite(new Texture(Gdx.files.internal("colleges/college-defeated-0.png")));
+            college.clearActions();
         }
         return totalAnimationDuration >= 10.0f; // only 'complete' the action when the Ship is killed.
     }

--- a/PirateGame/core/src/com/team21direction/pirategame/actors/College.java
+++ b/PirateGame/core/src/com/team21direction/pirategame/actors/College.java
@@ -60,15 +60,11 @@ public class College extends GameActor {
             if (!super.attack(damage)) {
                 collegeBase = new Sprite(collegeBases[0]);
                 this.addAction(new WhiteFlagRoutine());
+                screen.gold += screen.goldPerCollege;
                 isWhiteFlag = true;
             }
             else if (this.getHealth() < (this.getMaxHealth() / 2)) collegeBase = new Sprite(collegeBases[1]);
             else collegeBase = new Sprite(collegeBases[2]);
-        } else if (isWhiteFlag) {
-            isWhiteFlag = false;
-            screen.gold += screen.goldPerCollege;
-            this.clearActions();
-            collegeBase = new Sprite(new Texture(Gdx.files.internal("colleges/college-defeated-0.png")));
         }
         return isActive();
     }


### PR DESCRIPTION
Gold was only checked for if the college was attacked. This required another attack to be registered after the college surrendered.

Fix: Moved this check into the WhiteFlagRoutine to ensure both actions are operated on simultaneuosly.

Closes #13